### PR TITLE
Update tabs query to include only current window

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -17,7 +17,7 @@ function createActiveTabMessenger(message) {
           sendMessageToCurrentTab(id, message);
         });
       } else {
-        browser.tabs.query({ active: true }).then(function (currentTabs) {
+        browser.tabs.query({ currentWindow: true, active: true }).then(function (currentTabs) {
           sendMessageToCurrentTab(currentTabs[0].id, message);
         });
       }


### PR DESCRIPTION
Just using "active" when the user has multiple windows open can cause the wrong active tab to be selected, as there is one active tab per window.