### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,11 @@
   "manifest_version": 2,
   "name": "Clickster",
   "version": "1.1.1",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{d9a80c5d-e4ea-4d11-8437-aedf73f2028b}"
+    }
+  },
   "description": "Select an element to be automatically clicked at a determined interval.",
   "icons": {
     "48": "icons/48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Clickster",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Select an element to be automatically clicked at a determined interval.",
   "icons": {
     "48": "icons/48.png",


### PR DESCRIPTION
Version bump for the AMO release carrying #8 (tabs query restricted to current window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)