### PR TITLE
fix: re-selection crash when a target is already selected (#10)

### DIFF
--- a/clickster.js
+++ b/clickster.js
@@ -112,8 +112,8 @@ function setSelectedElement(event) {
     });
 
     removeHoverHighlight(lastHoveredElement);
-    Object.entries(selectedElementsToClick).forEach(([key, { ref }]) => {
-      removeSelectedHighlight(ref);
+    Object.entries(selectedElementsToClick).forEach(([key, value]) => {
+      removeSelectedHighlight(value);
       delete selectedElementsToClick[key];
     });
 

--- a/e2e/clickster.e2e.test.js
+++ b/e2e/clickster.e2e.test.js
@@ -54,6 +54,15 @@ function isSelected(style) {
   return style.includes("border-image") && style.includes("linear-gradient");
 }
 
+/** Poll until an element is (or is not) showing the selected highlight. */
+async function waitForSelected(elementId, selected = true, timeoutMs = 5000) {
+  await driver.wait(
+    async () => isSelected(await styleOf(elementId)) === selected,
+    timeoutMs,
+    `#${elementId} expected selected=${selected}`
+  );
+}
+
 /** In the open popup tab: wait for state sync, then press a popup button. */
 async function clickPopupButton(buttonId) {
   const button = await driver.wait(
@@ -62,6 +71,24 @@ async function clickPopupButton(buttonId) {
   );
   await driver.wait(until.elementIsVisible(button), 5000);
   await button.click();
+}
+
+/**
+ * Arm selection mode from the popup, then hover the target on the page and
+ * click it with a real pointer (exercising the page's elementFromPoint).
+ * Leaves the driver focused on the page-under-test.
+ */
+async function selectTargetByPointer(elementId) {
+  await openPopup();
+  await clickPopupButton("select-element-btn");
+  await driver.switchTo().window(pageHandle);
+  const target = await driver.findElement(By.id(elementId));
+  // Nudge to a neutral spot first: Selenium emits no mousemove when the
+  // pointer is already at the destination (e.g. re-selecting the element it
+  // last sat on), and the content script arms selection on mousemove.
+  await driver.actions().move({ x: 5, y: 5 }).perform();
+  await driver.actions().move({ origin: target }).perform();
+  await driver.actions().click().perform();
 }
 
 beforeAll(async () => {
@@ -79,15 +106,8 @@ describe("clickster in real Firefox", () => {
   it("selects a hovered element and repeatedly clicks it at the configured interval", async () => {
     await loadFixturePage();
 
-    // Arm selection mode from the popup. The popup closes itself afterwards.
-    await openPopup();
-    await clickPopupButton("select-element-btn");
-    await driver.switchTo().window(pageHandle);
-
     // Hover the target with a real pointer (real elementFromPoint) and click.
-    const buttonOne = await driver.findElement(By.id("one"));
-    await driver.actions().move({ origin: buttonOne }).perform();
-    await driver.actions().click().perform();
+    await selectTargetByPointer("one");
     expect(isSelected(await styleOf("one"))).toBe(true);
 
     // The popup reflects the selection and can start clicking.
@@ -158,5 +178,35 @@ describe("clickster in real Firefox", () => {
       return isSelected(await styleOf("one"));
     }, 5000);
     expect(isSelected(await styleOf("two"))).toBe(true);
+  }, 90000);
+
+  it("replaces the target when selecting a second element with one active", async () => {
+    // Start clean so nothing is auto-restored from an earlier test's query.
+    await driver.switchTo().window(pageHandle);
+    await driver.executeScript("localStorage.clear();");
+    await loadFixturePage();
+
+    // First selection on an empty slate works in any version.
+    await selectTargetByPointer("one");
+    await waitForSelected("one", true);
+
+    // Selecting a second element while "one" is active is the issue #10
+    // repro: setSelectedElement threw clearing the prior highlight, so the
+    // new selection silently failed and the popup kept saying "no target".
+    await selectTargetByPointer("two");
+    await waitForSelected("two", true);
+    await waitForSelected("one", false);
+
+    // "two" is now the sole live target: only its counter keeps climbing.
+    const oneBefore = await readCount("count-one");
+    await openPopup();
+    const intervalField = await driver.findElement(By.id("click-interval-fld"));
+    await intervalField.clear();
+    await intervalField.sendKeys("1");
+    await clickPopupButton("clickster-start-button");
+    await closePopup();
+    await driver.sleep(2500);
+    expect(await readCount("count-two")).toBeGreaterThanOrEqual(2);
+    expect(await readCount("count-one")).toBe(oneBefore);
   }, 90000);
 });

--- a/tests/content-script.test.js
+++ b/tests/content-script.test.js
@@ -86,6 +86,26 @@ describe("clickster content script", () => {
         "NO_ELEMENT_IS_SELECTED"
       );
     });
+
+    it("replaces the target when a new element is selected with one active", () => {
+      const first = document.getElementById("target");
+      const second = document.getElementById("other");
+      hoverAndSelect(first);
+
+      // Selecting again while a target is already active used to throw in
+      // setSelectedElement (issue #10) — it passed the raw element to
+      // removeSelectedHighlight, which dereferences element.ref — silently
+      // aborting the new selection so the popup kept saying "no target".
+      hoverAndSelect(second);
+
+      const clicksFirst = countClicks(first);
+      const clicksSecond = countClicks(second);
+      browser.emit("START_CLICKING");
+      vi.advanceTimersByTime(DEFAULT_INTERVAL_MS);
+
+      expect(clicksSecond).toHaveBeenCalledTimes(1);
+      expect(clicksFirst).not.toHaveBeenCalled();
+    });
   });
 
   describe("interval clicking", () => {


### PR DESCRIPTION
Fixes #10 — the highest-value bug from the AMO review analysis.

## The bug

`setSelectedElement` clears any existing selection before targeting the new element, but it passed the **raw DOM element** to `removeSelectedHighlight`:

```js
Object.entries(selectedElementsToClick).forEach(([key, { ref }]) => {
  removeSelectedHighlight(ref);   // ref is a DOM node
```

`removeSelectedHighlight` expects the **wrapper** object — it reads `element.ref.clicksterId`. With a raw node, `element.ref` is `undefined`, so it throws a `TypeError`, aborting the whole selection. The new target never gets set and the popup keeps reporting "no target selected."

This fires whenever a target already exists when you select — most insidiously when a cached advanced query auto-restores one on page load, after which **every** manual selection silently fails. That's almost certainly the [mikedufty review](https://addons.mozilla.org/firefox/addon/clickster/reviews/) ("always says no target selected").

## The fix

Pass the wrapper object, exactly as the working `manuallyClearSelectedElements` already does. One-line change.

## Regression coverage (both layers)

- **jsdom unit**: selecting a second element while one is active replaces it and clicks only the new one.
- **real-Firefox E2E**: arms selection, picks `#one`, then picks `#two` while `#one` is active, and asserts `#two` is the sole live clicking target. Verified to **fail on the pre-fix build** and pass after.

Also hardened the E2E pointer helper: Selenium emits no `mousemove` when the pointer is already at the destination, and the content script arms selection on `mousemove` — so re-selecting the same spot needs a nudge first. (Found via this very test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)