### PR TITLE
feat: live dev loop + playground page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "description": "Dev tooling for the Clickster web extension. The extension itself is plain JS with no build step.",
   "scripts": {
+    "dev": "node tools/dev.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "npm run build && vitest run --config vitest.e2e.config.js",
-    "lint": "web-ext lint --source-dir . --ignore-files 'dist/**' 'node_modules/**' 'tests/**' 'e2e/**' '.github/**' 'promo*.png' 'example.gif' 'test.html' '.prettierrc' '.gitattributes' 'PRIVACY_POLICY.md' 'README.md' 'ROADMAP.md' 'package.json' 'package-lock.json' 'vitest.config.js' 'vitest.e2e.config.js'",
+    "lint": "web-ext lint --source-dir . --ignore-files 'dist/**' 'node_modules/**' 'tests/**' 'e2e/**' 'playground/**' 'tools/**' '.github/**' 'promo*.png' 'example.gif' 'test.html' '.prettierrc' '.gitattributes' 'PRIVACY_POLICY.md' 'README.md' 'ROADMAP.md' 'package.json' 'package-lock.json' 'vitest.config.js' 'vitest.e2e.config.js'",
     "build": "mkdir -p dist && rm -f dist/clickster.zip && zip -r dist/clickster.zip manifest.json clickster.js popup icons LICENSE"
   },
   "devDependencies": {

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clickster Playground</title>
+    <style>
+      :root {
+        --rainbow: linear-gradient(
+          to right bottom,
+          #b827fc 0%,
+          #2c90fc 25%,
+          #b8fd33 50%,
+          #fec837 75%,
+          #fd1892 100%
+        );
+        --ink: #f4f0ff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        color: var(--ink);
+        background: radial-gradient(circle at 20% 0%, #2a1070, #160644 60%, #0c0330);
+        padding: 24px 18px 60px;
+      }
+      header {
+        text-align: center;
+        margin-bottom: 8px;
+      }
+      h1 {
+        font-size: 40px;
+        margin: 0;
+        background: var(--rainbow);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        letter-spacing: 1px;
+      }
+      .tagline {
+        opacity: 0.7;
+        margin: 4px 0 0;
+        font-size: 15px;
+      }
+      .hud {
+        display: flex;
+        gap: 14px;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin: 18px 0 26px;
+      }
+      .stat {
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        padding: 10px 18px;
+        min-width: 110px;
+        text-align: center;
+      }
+      .stat .num {
+        font-size: 26px;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+      }
+      .stat .lbl {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        opacity: 0.6;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 18px;
+        max-width: 980px;
+        margin: 0 auto;
+      }
+      .card {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 16px;
+        padding: 18px;
+        position: relative;
+        overflow: hidden;
+      }
+      .card h2 {
+        margin: 0 0 4px;
+        font-size: 18px;
+      }
+      .card .hint {
+        margin: 0 0 14px;
+        font-size: 13px;
+        opacity: 0.6;
+        min-height: 32px;
+      }
+      .card .hint code {
+        background: rgba(255, 255, 255, 0.12);
+        padding: 1px 5px;
+        border-radius: 4px;
+      }
+      button.toy {
+        font-size: 16px;
+        font-weight: 600;
+        color: #160644;
+        background: #f4f0ff;
+        border: none;
+        border-radius: 10px;
+        padding: 14px 18px;
+        cursor: pointer;
+        transition: transform 0.06s ease;
+      }
+      button.toy:active {
+        transform: scale(0.94);
+      }
+      .big {
+        width: 100%;
+        font-size: 22px;
+        padding: 22px;
+      }
+      .count {
+        font-variant-numeric: tabular-nums;
+        font-weight: 800;
+      }
+      .combo-row {
+        display: flex;
+        gap: 10px;
+      }
+      .combo-row button {
+        flex: 1;
+      }
+      .combo {
+        background: var(--rainbow);
+        color: #160644;
+      }
+      .arena {
+        position: relative;
+        height: 150px;
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 12px;
+        margin-top: 4px;
+      }
+      #mole {
+        position: absolute;
+        left: 20px;
+        top: 50px;
+      }
+      .leaves {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+      }
+      .leaf {
+        position: absolute;
+        font-size: 20px;
+        animation: fall 1.1s ease-in forwards;
+      }
+      @keyframes fall {
+        to {
+          transform: translateY(120px) rotate(220deg);
+          opacity: 0;
+        }
+      }
+      footer {
+        text-align: center;
+        margin-top: 30px;
+        font-size: 13px;
+        opacity: 0.5;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Clickster Playground</h1>
+      <p class="tagline">
+        Open the Clickster popup, pick a target, set a frequency, and watch it go.
+      </p>
+    </header>
+
+    <div class="hud">
+      <div class="stat">
+        <div class="num" id="hud-total">0</div>
+        <div class="lbl">Total clicks</div>
+      </div>
+      <div class="stat">
+        <div class="num" id="hud-cps">0.0</div>
+        <div class="lbl">Clicks / sec</div>
+      </div>
+      <div class="stat">
+        <div class="num" id="hud-best">0.0</div>
+        <div class="lbl">Best CPS</div>
+      </div>
+    </div>
+
+    <div class="grid">
+      <!-- 1. Primary idle target -->
+      <section class="card">
+        <h2>🍁 Harvest</h2>
+        <p class="hint">The classic. Point Clickster here and let it rip.</p>
+        <button id="harvest" class="toy big">
+          Harvest — <span class="count" id="harvest-count">0</span>
+        </button>
+        <div class="leaves" id="leaves"></div>
+      </section>
+
+      <!-- 2. Advanced multi-selector targets -->
+      <section class="card">
+        <h2>🌈 Combo</h2>
+        <p class="hint">
+          Three at once: open <em>Advanced</em> and apply <code>.combo</code>.
+        </p>
+        <div class="combo-row">
+          <button class="toy combo" data-name="water">
+            💧 <span class="count">0</span>
+          </button>
+          <button class="toy combo" data-name="sun">
+            ☀️ <span class="count">0</span>
+          </button>
+          <button class="toy combo" data-name="soil">
+            🌱 <span class="count">0</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- 3. Respawning button — showcases the stale-ref bug (#12) -->
+      <section class="card">
+        <h2>👻 Respawn</h2>
+        <p class="hint" id="respawn-hint">
+          This button is destroyed and recreated every 3s. Target it, then watch
+          what happens — today the clicks stop (issue #12).
+        </p>
+        <div class="arena" id="respawn-arena">
+          <button id="ghost" class="toy" style="position: absolute; left: 20px; top: 50px">
+            👻 <span class="count" id="ghost-count">0</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- 4. Moving target — whack-a-mole -->
+      <section class="card">
+        <h2>🐹 Whack-a-mole</h2>
+        <p class="hint">Same node, new spot every 1.5s. A steady target survives.</p>
+        <div class="arena" id="mole-arena">
+          <button id="mole" class="toy">
+            🐹 <span class="count" id="mole-count">0</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- 5. Reload tile — showcases persist-after-reload (#11) -->
+      <section class="card">
+        <h2>🔁 Reload</h2>
+        <p class="hint">
+          Start clicking a target, then reload. With #11 fixed, Clickster should
+          pick right back up. Today it goes quiet until you press Start again.
+        </p>
+        <button id="reload" class="toy big" onclick="location.reload()">
+          Reload the page
+        </button>
+      </section>
+
+      <!-- 6. Disabled-until-ready, a common automation case -->
+      <section class="card">
+        <h2>⏳ Patience</h2>
+        <p class="hint">Enables itself 2s after each click. Tests slow targets.</p>
+        <button id="patience" class="toy big">
+          Claim — <span class="count" id="patience-count">0</span>
+        </button>
+      </section>
+    </div>
+
+    <footer>Local dev playground · auto-reloads as the extension changes</footer>
+
+    <script>
+      const counts = Object.create(null);
+      let total = 0;
+      let bestCps = 0;
+      let windowClicks = 0;
+
+      function bump(key, spanEl) {
+        counts[key] = (counts[key] || 0) + 1;
+        spanEl.textContent = counts[key];
+        total += 1;
+        windowClicks += 1;
+        document.getElementById("hud-total").textContent = total;
+      }
+
+      // Harvest: spawn a falling leaf each click.
+      const harvest = document.getElementById("harvest");
+      const harvestCount = document.getElementById("harvest-count");
+      const leaves = document.getElementById("leaves");
+      const LEAVES = ["🍁", "🍂", "🌿", "🍃"];
+      harvest.addEventListener("click", () => {
+        bump("harvest", harvestCount);
+        const leaf = document.createElement("span");
+        leaf.className = "leaf";
+        leaf.textContent = LEAVES[total % LEAVES.length];
+        leaf.style.left = 10 + Math.floor((total * 37) % 260) + "px";
+        leaf.style.top = "0px";
+        leaves.appendChild(leaf);
+        setTimeout(() => leaf.remove(), 1100);
+      });
+
+      // Combo: three independent counters.
+      document.querySelectorAll(".combo").forEach((btn) => {
+        const span = btn.querySelector(".count");
+        btn.addEventListener("click", () => bump(btn.dataset.name, span));
+      });
+
+      // Whack-a-mole: same node teleports.
+      const mole = document.getElementById("mole");
+      const moleArena = document.getElementById("mole-arena");
+      const moleCount = document.getElementById("mole-count");
+      mole.addEventListener("click", () => bump("mole", moleCount));
+      let moleTick = 0;
+      setInterval(() => {
+        moleTick += 7;
+        const maxX = moleArena.clientWidth - mole.offsetWidth - 10;
+        const maxY = moleArena.clientHeight - mole.offsetHeight - 10;
+        mole.style.left = 10 + ((moleTick * 53) % Math.max(1, maxX)) + "px";
+        mole.style.top = 10 + ((moleTick * 29) % Math.max(1, maxY)) + "px";
+      }, 1500);
+
+      // Respawn: destroy and recreate the node (new DOM element each time).
+      const respawnArena = document.getElementById("respawn-arena");
+      function wireGhost(btn) {
+        const span = btn.querySelector(".count");
+        btn.addEventListener("click", () => bump("ghost", span));
+      }
+      wireGhost(document.getElementById("ghost"));
+      setInterval(() => {
+        const old = document.getElementById("ghost");
+        const carried = counts["ghost"] || 0;
+        old.remove();
+        const fresh = document.createElement("button");
+        fresh.id = "ghost";
+        fresh.className = "toy";
+        fresh.style.cssText = "position:absolute; left:20px; top:50px";
+        fresh.innerHTML = '👻 <span class="count" id="ghost-count">' + carried + "</span>";
+        respawnArena.appendChild(fresh);
+        wireGhost(fresh);
+      }, 3000);
+
+      // Patience: disables for 2s after each click.
+      const patience = document.getElementById("patience");
+      const patienceCount = document.getElementById("patience-count");
+      patience.addEventListener("click", () => {
+        bump("patience", patienceCount);
+        patience.disabled = true;
+        setTimeout(() => (patience.disabled = false), 2000);
+      });
+
+      // HUD: clicks-per-second over a rolling 1s window.
+      setInterval(() => {
+        const cps = windowClicks;
+        windowClicks = 0;
+        document.getElementById("hud-cps").textContent = cps.toFixed(1);
+        if (cps > bestCps) {
+          bestCps = cps;
+          document.getElementById("hud-best").textContent = bestCps.toFixed(1);
+        }
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/tools/dev.mjs
+++ b/tools/dev.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Live dev loop: serve the playground, launch Firefox with Clickster loaded as
+// a temporary add-on, and auto-reload the extension whenever a source file
+// changes. Stop with Ctrl-C.
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const playgroundDir = join(repoRoot, "playground");
+const PORT = 8910;
+
+const TYPES = {
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "text/javascript",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+const server = createServer(async (req, res) => {
+  let path = normalize(new URL(req.url, "http://localhost").pathname);
+  if (path === "/") path = "/index.html";
+  try {
+    const body = await readFile(join(playgroundDir, path));
+    res.writeHead(200, { "Content-Type": TYPES[extname(path)] ?? "text/plain" });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end("not found");
+  }
+});
+
+server.listen(PORT, () => {
+  const url = `http://localhost:${PORT}/`;
+  console.log(`\n  Playground:  ${url}`);
+  console.log("  Launching Firefox with Clickster (temporary add-on)…\n");
+
+  // Watch only the shipped extension files so edits to tests/tooling don't
+  // trigger reloads. web-ext reinstalls the add-on on each change.
+  const watched = [
+    "manifest.json",
+    "clickster.js",
+    "popup/popup.html",
+    "popup/popup.js",
+  ];
+  const args = [
+    "web-ext",
+    "run",
+    "--source-dir=.",
+    `--start-url=${url}`,
+    // Quiet the fresh-profile first-run UI so only the playground shows.
+    "--pref=browser.aboutwelcome.enabled=false",
+    "--pref=browser.messaging-system.whatsNewPanel.enabled=false",
+    "--pref=datareporting.policy.dataSubmissionEnabled=false",
+    ...watched.flatMap((f) => ["--watch-file", f]),
+  ];
+
+  const child = spawn("npx", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+
+  const shutdown = () => {
+    child.kill("SIGTERM");
+    server.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+  child.on("exit", (code) => {
+    server.close();
+    process.exit(code ?? 0);
+  });
+});


### PR DESCRIPTION
Adds a one-command live development environment and a fun playground to exercise the extension by hand as it changes.

## `npm run dev`

Serves the playground and launches Firefox with Clickster installed as a temporary add-on, **auto-reloading whenever a shipped extension file changes** (`manifest.json`, `clickster.js`, `popup/*`). Built on `web-ext run` — no build step, consistent with how the extension ships. First-run profile noise (welcome overlay, what's-new) is suppressed via prefs so only the playground shows.

Requires a local Firefox (`brew install --cask firefox` on macOS).

## The playground

A self-contained "clicker arcade" (`playground/index.html`) that's enjoyable to auto-click and doubles as a manual companion to the E2E suite — each tile maps to a real scenario:

| Tile | Exercises |
|------|-----------|
| 🍁 Harvest | the classic single idle target (spawns falling leaves) |
| 🌈 Combo | three buttons via an advanced `.combo` selector query |
| 👻 Respawn | a node destroyed & recreated every 3s — the stale-ref bug (#12) |
| 🐹 Whack-a-mole | a steady node that moves — should keep clicking |
| 🔁 Reload | persist-after-reload (#11) |
| ⏳ Patience | a target that disables itself for 2s after each click |

Plus a live HUD: total clicks, clicks/sec, best CPS.

Excluded from the AMO zip (the build script only packages runtime files) and from `web-ext lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)