### PR TITLE
feat: sticky resume toast when clicking persists across reloads

### DIFF
--- a/clickster.js
+++ b/clickster.js
@@ -285,6 +285,76 @@ function applyQuery(query) {
   startClicking();
 }
 
+function dismissResumeToast() {
+  const existing = document.getElementById("clickster-resume-toast");
+  if (existing) {
+    existing.remove();
+  }
+}
+
+// Sticky on-page banner shown when clicking silently resumes after a reload,
+// so it's never a mystery why a page is clicking itself. Stays until the user
+// acts (it is not auto-dismissed).
+function showResumeToast() {
+  if (localStorage.getItem("clicksterHideResumeToast") === "true") return;
+  if (!document.body || document.getElementById("clickster-resume-toast")) {
+    return;
+  }
+
+  const toast = document.createElement("div");
+  toast.id = "clickster-resume-toast";
+  toast.setAttribute("role", "status");
+  toast.style.cssText =
+    "position:fixed;bottom:16px;right:16px;z-index:2147483647;max-width:320px;" +
+    "padding:14px 16px;background:#160644;color:#f4f0ff;border:2px solid #b8fd33;" +
+    "border-radius:10px;font-family:Helvetica,Arial,sans-serif;font-size:13px;" +
+    "line-height:1.4;box-shadow:0 6px 24px rgba(0,0,0,0.4)";
+
+  const message = document.createElement("div");
+  message.textContent = "Clickster is still auto-clicking on this page.";
+  message.style.cssText = "margin-bottom:10px;font-weight:bold";
+
+  const actions = document.createElement("div");
+  actions.style.cssText = "display:flex;gap:8px;align-items:center";
+
+  const stopButton = document.createElement("button");
+  stopButton.id = "clickster-resume-toast-stop";
+  stopButton.textContent = "Stop";
+  stopButton.style.cssText =
+    "background:#bf16ab;color:#fff;border:none;border-radius:5px;" +
+    "padding:6px 12px;font-size:13px;cursor:pointer";
+  stopButton.addEventListener("click", () => {
+    setClicksterEnabled(false);
+    stopClicking();
+    dismissResumeToast();
+  });
+
+  const keepButton = document.createElement("button");
+  keepButton.textContent = "Keep clicking";
+  keepButton.style.cssText =
+    "background:transparent;color:#cfc8f5;border:1px solid rgba(255,255,255,0.3);" +
+    "border-radius:5px;padding:6px 12px;font-size:13px;cursor:pointer";
+  keepButton.addEventListener("click", dismissResumeToast);
+
+  const hideLink = document.createElement("a");
+  hideLink.textContent = "Don't show again";
+  hideLink.href = "#";
+  hideLink.style.cssText =
+    "color:#9189c0;font-size:12px;margin-left:auto;text-decoration:underline;cursor:pointer";
+  hideLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    localStorage.setItem("clicksterHideResumeToast", "true");
+    dismissResumeToast();
+  });
+
+  actions.appendChild(stopButton);
+  actions.appendChild(keepButton);
+  actions.appendChild(hideLink);
+  toast.appendChild(message);
+  toast.appendChild(actions);
+  document.body.appendChild(toast);
+}
+
 // Re-resolve persisted target selectors after a page load and resume clicking
 // if it was running. This is what makes clicking survive a reload (issue #11).
 function restoreTargets() {
@@ -315,6 +385,9 @@ function restoreTargets() {
   });
   if (Object.keys(selectedElementsToClick).length > 0) {
     startClicking();
+    if (clicksterEnabled) {
+      showResumeToast();
+    }
   }
 }
 

--- a/e2e/clickster.e2e.test.js
+++ b/e2e/clickster.e2e.test.js
@@ -254,4 +254,40 @@ describe("clickster in real Firefox", () => {
       "clicking did not resume after reload"
     );
   }, 90000);
+
+  it("shows a sticky resume toast whose Stop button halts clicking", async () => {
+    await loadFixturePage();
+    await selectTargetByPointer("one");
+    await waitForSelected("one", true);
+
+    await openPopup();
+    const intervalField = await driver.findElement(By.id("click-interval-fld"));
+    await intervalField.clear();
+    await intervalField.sendKeys("1");
+    await clickPopupButton("clickster-start-button");
+    await closePopup();
+    await driver.wait(async () => (await readCount("count-one")) >= 1, 5000);
+
+    // After reload the resume toast appears on the page (no popup needed).
+    await reloadFixturePage();
+    const stop = await driver.wait(
+      until.elementLocated(By.id("clickster-resume-toast-stop")),
+      8000
+    );
+    await driver.wait(until.elementIsVisible(stop), 5000);
+
+    // It must be sticky — present a moment later, not auto-dismissed.
+    await driver.sleep(1500);
+    await stop.click();
+
+    // Stop halts clicking and removes the toast.
+    await driver.wait(
+      until.stalenessOf(stop),
+      5000,
+      "toast did not dismiss on Stop"
+    );
+    const afterStop = await readCount("count-one");
+    await driver.sleep(2000);
+    expect(await readCount("count-one")).toBe(afterStop);
+  }, 90000);
 });

--- a/tests/content-script.test.js
+++ b/tests/content-script.test.js
@@ -307,4 +307,66 @@ describe("clickster content script", () => {
       expect(clicks).not.toHaveBeenCalled();
     });
   });
+
+  describe("resume toast", () => {
+    function reload() {
+      vi.clearAllTimers();
+      browser = installBrowserMock();
+      loadScript("clickster.js");
+    }
+    const toast = () => document.getElementById("clickster-resume-toast");
+
+    it("shows a sticky toast when clicking resumes after reload", () => {
+      hoverAndSelect(document.getElementById("target"));
+      browser.emit("START_CLICKING");
+      expect(toast()).toBeNull(); // not while the user is actively on the page
+
+      reload();
+      expect(toast()).not.toBeNull();
+      expect(toast().textContent).toContain("still auto-clicking");
+    });
+
+    it("does not show a toast when clicking did not resume", () => {
+      hoverAndSelect(document.getElementById("target"));
+      browser.emit("START_CLICKING");
+      browser.emit("STOP_CLICKING");
+
+      reload();
+      expect(toast()).toBeNull();
+    });
+
+    it("its Stop button halts clicking and removes the toast", () => {
+      const target = document.getElementById("target");
+      hoverAndSelect(target);
+      browser.emit("START_CLICKING");
+      reload();
+
+      document.getElementById("clickster-resume-toast-stop").click();
+      expect(toast()).toBeNull();
+
+      const clicks = countClicks(target);
+      vi.advanceTimersByTime(DEFAULT_INTERVAL_MS * 2);
+      expect(clicks).not.toHaveBeenCalled();
+      // The stop persists, so the next reload stays quiet too.
+      reload();
+      expect(toast()).toBeNull();
+    });
+
+    it("suppresses the toast permanently after 'Don't show again'", () => {
+      hoverAndSelect(document.getElementById("target"));
+      browser.emit("START_CLICKING");
+      reload();
+
+      const link = [...toast().querySelectorAll("a")].find((a) =>
+        a.textContent.includes("Don't show again")
+      );
+      link.click();
+      expect(toast()).toBeNull();
+      expect(localStorage.getItem("clicksterHideResumeToast")).toBe("true");
+
+      // Still clicking, but the toast no longer appears on later reloads.
+      reload();
+      expect(toast()).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #11 (which merged before this was ready, so it lands as its own PR).

Now that clicking survives a reload, a page clicking itself with no visible cause is alarming. When `restoreTargets` resumes clicking on load, the content script injects a **sticky on-page banner**:

> Clickster is still auto-clicking on this page.   [Stop] [Keep clicking] · Don't show again

- **Stop** halts clicking (and persists the stop, so it stays quiet on later reloads).
- **Keep clicking** dismisses the banner but leaves clicking running.
- **Don't show again** suppresses the banner permanently (localStorage flag).
- It is **never auto-dismissed** — sticky until the user acts — and only appears for *reload-resumed* clicking, never user-initiated Start.

## Tests
- jsdom unit: appears on resume, not when stopped; Stop halts clicking and removes it; Don't-show-again suppresses it on later reloads.
- real-Firefox E2E: reload shows the toast, it persists (sticky), and its Stop button halts clicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)