### PR TITLE
feat: coordinate-clicking v2 polish — robustness + crosshair drag (#34, #35, #33)

### DIFF
--- a/clickster.js
+++ b/clickster.js
@@ -110,28 +110,70 @@ function positionMarker(target) {
 function createMarker(target) {
   const marker = document.createElement("div");
   marker.className = "clickster-crosshair";
+  // The container is 0x0 (no hit area); its parts are pointer-events:none so
+  // they never intercept the clicks they mark. Only the drag handle becomes
+  // interactive, and only while clicking is stopped.
   marker.style.cssText =
-    "position:fixed;left:0;top:0;width:0;height:0;pointer-events:none;z-index:2147483646;";
+    "position:fixed;left:0;top:0;width:0;height:0;z-index:2147483646;";
   const hbar = document.createElement("div");
   hbar.style.cssText =
-    "position:absolute;left:-16px;top:-1.5px;width:32px;height:3px;border-radius:2px;background:" +
+    "position:absolute;left:-16px;top:-1.5px;width:32px;height:3px;border-radius:2px;pointer-events:none;background:" +
     RAINBOW_GRADIENT;
   const vbar = document.createElement("div");
   vbar.style.cssText =
-    "position:absolute;left:-1.5px;top:-16px;width:3px;height:32px;border-radius:2px;background:" +
+    "position:absolute;left:-1.5px;top:-16px;width:3px;height:32px;border-radius:2px;pointer-events:none;background:" +
     RAINBOW_GRADIENT;
   // A fixed-size circle that flashes on each click (the click emphasis).
   const pulse = document.createElement("div");
   pulse.className = "clickster-crosshair-pulse";
   pulse.style.cssText =
-    "position:absolute;left:-13px;top:-13px;width:26px;height:26px;border-radius:50%;opacity:0;box-shadow:" +
+    "position:absolute;left:-13px;top:-13px;width:26px;height:26px;border-radius:50%;opacity:0;pointer-events:none;box-shadow:" +
     SELECTED_SHADOW;
+  // Transparent drag handle to nudge the exact pixel (only while stopped).
+  const handle = document.createElement("div");
+  handle.className = "clickster-crosshair-handle";
+  handle.style.cssText =
+    "position:absolute;left:-18px;top:-18px;width:36px;height:36px;border-radius:50%;cursor:move;pointer-events:" +
+    (clicksterEnabled ? "none" : "auto");
+  handle.addEventListener("mousedown", (event) => {
+    if (clicksterEnabled) return;
+    event.preventDefault();
+    event.stopPropagation();
+    draggingTarget = target;
+  });
   marker.appendChild(pulse);
   marker.appendChild(hbar);
   marker.appendChild(vbar);
+  marker.appendChild(handle);
   document.body.appendChild(marker);
   target.markerEl = marker;
   positionMarker(target);
+}
+
+// While a crosshair handle is grabbed, move the point with the cursor and
+// recompute its offset within the anchor.
+let draggingTarget = null;
+document.addEventListener("mousemove", (event) => {
+  if (!draggingTarget || !draggingTarget.ref) return;
+  const rect = draggingTarget.ref.getBoundingClientRect();
+  if (!rect.width || !rect.height) return;
+  draggingTarget.offsetX = clamp01((event.clientX - rect.left) / rect.width);
+  draggingTarget.offsetY = clamp01((event.clientY - rect.top) / rect.height);
+  positionMarker(draggingTarget);
+});
+document.addEventListener("mouseup", () => {
+  if (draggingTarget) {
+    persistTargets();
+    draggingTarget = null;
+  }
+});
+
+function setMarkersInteractive(interactive) {
+  targets.forEach((t) => {
+    if (!t.markerEl) return;
+    const handle = t.markerEl.querySelector(".clickster-crosshair-handle");
+    if (handle) handle.style.pointerEvents = interactive ? "auto" : "none";
+  });
 }
 
 function removeMarker(target) {
@@ -669,10 +711,12 @@ browser.runtime.onMessage.addListener(function (message) {
     targets.forEach((target) => {
       target.lastClickedAt = now;
     });
+    setMarkersInteractive(false);
     startClicking();
   } else if (message === "STOP_CLICKING") {
     setClicksterEnabled(false);
     stopClicking();
+    setMarkersInteractive(true);
   } else if (message && message.removeTargetId !== undefined) {
     removeTarget(message.removeTargetId);
   } else if (message && message.setTargetInterval) {

--- a/clickster.js
+++ b/clickster.js
@@ -393,9 +393,12 @@ function resolveTarget(target) {
 // element.click() — so it works for canvas/coordinate games and for sites that
 // ignore synthetic clicks. Dispatches on whatever element is actually at the
 // point. Events are isTrusted:false (not an anti-cheat bypass).
-function dispatchClickAt(clientX, clientY) {
+function dispatchClickAt(clientX, clientY, anchor) {
   const target = document.elementFromPoint(clientX, clientY);
-  if (!target || typeof target.dispatchEvent !== "function") return;
+  if (!target || typeof target.dispatchEvent !== "function") return false;
+  // Skip if the anchor isn't actually at this point — scrolled off-screen, or
+  // hidden behind a modal/overlay — so we never click the wrong element.
+  if (anchor && anchor !== target && !anchor.contains(target)) return false;
   const base = {
     bubbles: true,
     cancelable: true,
@@ -419,6 +422,7 @@ function dispatchClickAt(clientX, clientY) {
   if (hasPointer) target.dispatchEvent(new PointerEvent("pointerup", pointer(0)));
   target.dispatchEvent(new MouseEvent("mouseup", { ...base, buttons: 0 }));
   target.dispatchEvent(new MouseEvent("click", { ...base, buttons: 0 }));
+  return true;
 }
 
 function tick() {
@@ -437,10 +441,13 @@ function tick() {
       target.markerEl.style.top = y + "px";
     }
     if (now - target.lastClickedAt >= target.intervalMs) {
-      dispatchClickAt(x, y);
-      target.clickCount += 1;
-      target.lastClickedAt = now;
-      pulseClicked(target);
+      // Only count it if the click actually reached the target; otherwise
+      // (off-screen / occluded) leave it due and retry next tick.
+      if (dispatchClickAt(x, y, ref)) {
+        target.clickCount += 1;
+        target.lastClickedAt = now;
+        pulseClicked(target);
+      }
     }
   });
 }

--- a/e2e/clickster.e2e.test.js
+++ b/e2e/clickster.e2e.test.js
@@ -451,4 +451,34 @@ describe("clickster in real Firefox", () => {
     expect(Math.abs(x - 100)).toBeLessThan(20);
     expect(Math.abs(y - 60)).toBeLessThan(20);
   }, 90000);
+
+  it("drags the crosshair to fine-tune the canvas point (#33)", async () => {
+    await loadFixturePage();
+    await selectTargetByPointer("game"); // crosshair at the canvas centre
+
+    // While stopped, drag the crosshair handle 30px to the right.
+    const handle = await driver.findElement(
+      By.css(".clickster-crosshair-handle")
+    );
+    await driver
+      .actions()
+      .move({ origin: handle })
+      .press()
+      .move({ origin: "pointer", x: 30, y: 0 })
+      .release()
+      .perform();
+
+    // Start; clicks now land right of centre (canvas x > 110).
+    await openPopup();
+    await clickPopupButton("start-btn");
+    await closePopup();
+    await driver.wait(
+      async () => {
+        const last = await driver.findElement(By.id("game-last")).getText();
+        return Number(last.split(",")[0]) > 110;
+      },
+      6000,
+      "drag did not move the click point"
+    );
+  }, 90000);
 });

--- a/e2e/clickster.e2e.test.js
+++ b/e2e/clickster.e2e.test.js
@@ -419,9 +419,35 @@ describe("clickster in real Firefox", () => {
     // The cookie only counts clicks that land inside its circle.
     await driver.wait(async () => (await readCount("count-game")) >= 2, 6000);
 
-    // And the recorded click landed near the canvas centre (100,60).
+    // And the recorded click landed near the canvas centre (100,60) — this also
+    // confirms the mapping holds for the CSS-scaled (1.5x) canvas.
     const last = await driver.findElement(By.id("game-last")).getText();
     const [x, y] = last.split(",").map(Number);
+    expect(Math.abs(x - 100)).toBeLessThan(20);
+    expect(Math.abs(y - 60)).toBeLessThan(20);
+  }, 90000);
+
+  it("keeps hitting the canvas point after scrolling (#34)", async () => {
+    await loadFixturePage();
+    await selectTargetByPointer("game");
+    await openPopup();
+    await clickPopupButton("start-btn");
+    await closePopup();
+    await driver.wait(async () => (await readCount("count-game")) >= 1, 6000);
+
+    // Scroll the page; the anchor's offset is normalized, so the click should
+    // still land on the cookie at its new screen position.
+    await driver.executeScript("window.scrollTo(0, 120);");
+    const before = await readCount("count-game");
+    await driver.wait(
+      async () => (await readCount("count-game")) > before,
+      6000,
+      "clicking did not survive scrolling"
+    );
+    // The recorded canvas-pixel coordinate is still the cookie centre.
+    const [x, y] = (await driver.findElement(By.id("game-last")).getText())
+      .split(",")
+      .map(Number);
     expect(Math.abs(x - 100)).toBeLessThan(20);
     expect(Math.abs(y - 60)).toBeLessThan(20);
   }, 90000);

--- a/e2e/fixtures/counter.html
+++ b/e2e/fixtures/counter.html
@@ -18,8 +18,14 @@
     <div id="respawn-host">
       <button id="respawn">Respawn (<span id="count-respawn">0</span>)</button>
     </div>
-    <!-- A canvas that only registers coordinate clicks (not element.click). -->
-    <canvas id="game" width="200" height="120" style="margin: 20px"></canvas>
+    <!-- A canvas that only registers coordinate clicks (not element.click).
+         CSS-scaled 1.5x to exercise coordinate mapping under scaling/DPR. -->
+    <canvas
+      id="game"
+      width="200"
+      height="120"
+      style="margin: 20px; width: 300px; height: 180px"
+    ></canvas>
     <div>
       cookie clicks: <span id="count-game">0</span> · last:
       <span id="game-last">-</span>
@@ -35,8 +41,11 @@
         let gameClicks = 0;
         canvas.addEventListener("mousedown", (e) => {
           const r = canvas.getBoundingClientRect();
-          const x = Math.round(e.clientX - r.left);
-          const y = Math.round(e.clientY - r.top);
+          // Map the CSS-pixel click to canvas pixels (the canvas is scaled).
+          const x = Math.round((e.clientX - r.left) * (canvas.width / r.width));
+          const y = Math.round(
+            (e.clientY - r.top) * (canvas.height / r.height)
+          );
           document.getElementById("game-last").textContent = x + "," + y;
           // Only count clicks that land inside the cookie circle.
           if ((x - 100) * (x - 100) + (y - 60) * (y - 60) <= 40 * 40) {
@@ -47,6 +56,8 @@
         });
       })();
     </script>
+    <!-- Tall spacer so the page scrolls (for the scroll-survival test). -->
+    <div style="height: 1200px"></div>
     <script>
       let one = 0;
       let two = 0;

--- a/playground/index.html
+++ b/playground/index.html
@@ -276,7 +276,8 @@
         <h2>🍪 Canvas cookie</h2>
         <p class="hint">
           A canvas only registers coordinate clicks. Point Clickster at the
-          cookie — <span class="count" id="cookie-count">0</span> baked.
+          cookie, then drag the crosshair to aim —
+          <span class="count" id="cookie-count">0</span> baked.
         </p>
         <canvas
           id="cookie"

--- a/tests/content-script.test.js
+++ b/tests/content-script.test.js
@@ -276,6 +276,22 @@ describe("clickster content script", () => {
       }
     });
 
+    it("does not click an element occluding the target's point (#35)", () => {
+      const target = document.getElementById("target");
+      hoverAndSelect(target);
+
+      // An overlay covering the target's point wins the hit-test.
+      const occluder = place(document.createElement("div"), 0, 0, 100, 40);
+      document.body.appendChild(occluder);
+      const occluderClicks = countClicks(occluder);
+
+      browser.emit("START_CLICKING");
+      vi.advanceTimersByTime(INTERVAL_MS * 2);
+
+      expect(occluderClicks).not.toHaveBeenCalled();
+      expect(state().targets[0].clickCount).toBe(0);
+    });
+
     it("pauses and resumes an individual target", () => {
       const target = document.getElementById("target");
       const other = document.getElementById("other");

--- a/tests/content-script.test.js
+++ b/tests/content-script.test.js
@@ -362,6 +362,25 @@ describe("clickster content script", () => {
       expect(marker.style.top).toBe("70px");
     });
 
+    it("drags the crosshair to reposition the point while stopped (#33)", () => {
+      const canvas = selectCanvas(); // canvas at 20,20,200,100 → offset 0.5,0.5
+      const handle = document.querySelector(".clickster-crosshair-handle");
+
+      handle.dispatchEvent(
+        new MouseEvent("mousedown", { clientX: 120, clientY: 70, bubbles: true })
+      );
+      // Drag to (60, 45): offset (60-20)/200=0.2, (45-20)/100=0.25.
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 60, clientY: 45, bubbles: true })
+      );
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+      const stored = JSON.parse(localStorage.getItem("clicksterTargets"));
+      expect(stored[0].offsetX).toBeCloseTo(0.2);
+      expect(stored[0].offsetY).toBeCloseTo(0.25);
+      expect(canvas).toBeTruthy();
+    });
+
     it("removes the crosshair when the target is removed", () => {
       selectCanvas();
       expect(document.querySelector(".clickster-crosshair")).not.toBeNull();


### PR DESCRIPTION
Hardens the XY clicking from #36 for v2. Part of epic #28.

## Occlusion / off-screen guard (#35)
`dispatchClickAt` now takes the anchor and verifies `elementFromPoint` at the point **is** that anchor (or inside it). If a modal/overlay covers the target, or it's scrolled off-screen, the click is **skipped** (left due, retried next tick) rather than clicking the wrong element. Unit test asserts the occluding element is never clicked and the count stays 0.

## Scroll & scale survival (#34)
- The E2E canvas fixture is now **CSS-scaled 1.5×**, so the "click lands at the right canvas pixel" test also proves the coordinate mapping is correct under scaling / `devicePixelRatio` (we work in CSS pixels; the game maps to canvas pixels).
- New E2E: **scroll the page** and assert clicking still lands on the cookie at its new screen position — the normalized anchor offset survives scroll.

**45 unit + 13 E2E green.**

Remaining epic items: #33 (precision nudge/drag). Rotation transforms and pointer-lock stay documented non-goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)