### PR TITLE
release: 2.0.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
   "manifest_version": 2,
   "name": "Clickster",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "{d9a80c5d-e4ea-4d11-8437-aedf73f2028b}"
     }
   },
-  "description": "Select an element to be automatically clicked at a determined interval.",
+  "description": "Auto-click any element — or a point on a canvas/game — at a rate you choose, with multiple targets at once.",
   "icons": {
     "48": "icons/48.png",
     "96": "icons/96.png",


### PR DESCRIPTION
Bumps `manifest.json` to **2.0.0** and refreshes the description. This is the major release assembling everything on `main`:

## What's in 2.0
- **Reliability** (the AMO-review fixes): re-selection crash (#10), clicking survives reload/navigation (#11) with a resume toast, stale-ref re-resolve for SPA re-renders (#12), dropped deprecated `tabs.getSelected` (#15).
- **Redesigned popup** (#27): a managed list of targets — each with live click count, countdown, its own frequency, pause/resume, an eyeball to locate it, and remove. Rounded rainbow ring highlight + a click "squish" animation.
- **Universal coordinate (x,y) clicking** (#28): every click is a real `pointerdown→…→click` at an anchored point, so it works on **canvas games** and on sites that ignore `element.click()`. Canvas/svg/video points show a **rainbow crosshair** (with a fixed-size click-emphasis circle) you can **drag to aim**. Survives scroll/resize/scale; skips occluded/off-screen points.

Backed by **46 unit + 14 real-Firefox E2E tests**.

## To publish
After merge: `npm run build` (the zip is already built at `dist/clickster.zip`), then upload at the AMO Developer Hub → answer **No** to the source-code question (plain unminified JS, no build step). Consider refreshing the AMO listing copy to mention canvas/game support and the new multi-target UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)